### PR TITLE
fix(PullRequest) ensure comments from PR author are excluded

### DIFF
--- a/lib/review_bot/pull_request.rb
+++ b/lib/review_bot/pull_request.rb
@@ -108,7 +108,8 @@ module ReviewBot
 
     def reviews_from_other_humans
       reviews_from_humans.select do |r|
-        r.user.login != user.login && notify_in_progress_reviewers? ? r.approved? : true
+        r.user.login != user.login &&
+          (notify_in_progress_reviewers? ? r.approved? : true)
       end
     end
 


### PR DESCRIPTION
I noticed that reviewbot was considering comments from the PR author as reviews, and it looks like  the culprit is operator precedence.

To illustrate:
```ruby
>> false && true ? false : true
=> true
>> false && (true ? false : true)
=> false
```