### PR TITLE
Provide config to reverse sort order of notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ There are two main strategies for using the reviewbot. If you want to run it at 
 | ez_labels | Shows up as a slack emoji `:ez:` if the PR has an EZ or ez label applied
 | plus_ones | Shows up as a slack emoji `:plus_one:` if pull request has one plus_one
 | author_emoji | Shows up as a slack emoji pulled from either the list of reviewers or the github name
+| sort_asc | Reverses order of displayed notifications
 
 ##### Reviewer
 

--- a/lib/review_bot/reminder.rb
+++ b/lib/review_bot/reminder.rb
@@ -52,8 +52,13 @@ module ReviewBot
       @notifications ||= potential_notifications.compact
     end
 
+    def sorted_pull_requests
+      pulls = GH.pulls.list(owner, repo).body
+      app_config['sort_asc'] ? pulls.reverse : pulls
+    end
+
     def potential_notifications
-      GH.pulls.list(owner, repo).body.map do |p|
+      sorted_pull_requests.map do |p|
         pull = PullRequest.new(p, { notify_in_progress_reviewers: app_config['notify_in_progress_reviewers'] })
 
         print '.'


### PR DESCRIPTION
Moves newer PR's to the top instead of the bottom based on a config line - 
Before:
![image](https://user-images.githubusercontent.com/6271986/56067899-b8fed580-5d31-11e9-9a59-9ca74450ec24.png)

After
![image](https://user-images.githubusercontent.com/6271986/56068109-7ab5e600-5d32-11e9-80ed-ea5e72086c67.png)
