### PR TITLE
feat(Messages) separate messaging

### DIFF
--- a/lib/review_bot/reminder.rb
+++ b/lib/review_bot/reminder.rb
@@ -14,11 +14,6 @@ module ReviewBot
       @app_config = app_config
     end
 
-    def message
-      return if notifications.empty?
-      notifications.map(&:message).join("\n")
-    end
-
     def messages
       return if notifications.empty?
       notifications.map(&:message)

--- a/lib/review_bot/reminder.rb
+++ b/lib/review_bot/reminder.rb
@@ -19,6 +19,11 @@ module ReviewBot
       notifications.map(&:message).join("\n")
     end
 
+    def messages
+      return if notifications.empty?
+      notifications.map(&:message)
+    end
+
     def app_reviewers
       @app_reviewers ||= app_config['reviewers'].map { |r| Reviewer.new(r) }
     end

--- a/review.rake
+++ b/review.rake
@@ -22,27 +22,29 @@ task :remind, [:mode] do |_t, args|
 
     ReviewBot::HourOfDay.work_days = app_config['work_days']
 
-    message = ReviewBot::Reminder.new(owner, repo, app_config).message
+    messages = ReviewBot::Reminder.new(owner, repo, app_config).messages
+    messages.each do |message|
 
-    puts
-
-    next if message.nil?
-
-    if dry_run
-      puts "Would deliver message to #{room}"
-      puts message
       puts
-    else
-      puts "Delivering a message to #{room}"
 
-      RestClient.post(
-        'https://slack.com/api/chat.postMessage',
-        token: SLACK_TOKEN,
-        channel: room,
-        text: message,
-        icon_emoji: SLACK_BOT_ICON,
-        username: SLACK_BOT_NAME
-      )
+      next if message.nil?
+
+      if dry_run
+        puts "Would deliver message to #{room}"
+        puts message
+        puts
+      else
+        puts "Delivering a message to #{room}"
+
+        RestClient.post(
+          'https://slack.com/api/chat.postMessage',
+          token: SLACK_TOKEN,
+          channel: room,
+          text: message,
+          icon_emoji: SLACK_BOT_ICON,
+          username: SLACK_BOT_NAME
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This was requested by someone on my team. Proposing the change here. What this does is send separate messages per notification rather than one large message with all the notifications. This allows  for people to add in emojis and icons into each individual notification. We do this oftentimes to tell others that we are looking: 👀 or to show that it is finished and communicate that no one else needs to look at it. 

![image](https://user-images.githubusercontent.com/6271986/56167254-8ef51f80-5f8c-11e9-9ddc-63db4904e5f4.png)
