### PR TITLE
prevent from notifying on weekends

### DIFF
--- a/lib/review_bot/hour_of_day.rb
+++ b/lib/review_bot/hour_of_day.rb
@@ -39,6 +39,10 @@ module ReviewBot
       self.class.work_days.include?(rounded_time.wday) && WORK_DAY_HOURS.include?(rounded_time.hour)
     end
 
+    def work_day?
+      self.class.work_days.include?(rounded_time.wday)
+    end
+
     def inspect
       "HourOfDay(#{rounded_time.strftime('%a-%I%P')} work_hour: #{work_hour?})"
     end

--- a/lib/review_bot/reminder.rb
+++ b/lib/review_bot/reminder.rb
@@ -85,6 +85,7 @@ module ReviewBot
 
         care_about_work_hours = !app_config['ignore_work_hours']
         next if care_about_work_hours && suggested_reviewers.select(&:work_hour?).empty?
+        next if suggested_reviewers.select(&:work_day?).empty?
 
         Notification.new(
           pull_request: pull,

--- a/lib/review_bot/reviewer.rb
+++ b/lib/review_bot/reviewer.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 module ReviewBot
   class Reviewer < OpenStruct
+    attr_reader :hour_of_day
+
+    def initialize(r)
+      super
+      @hour_of_day = HourOfDay.new(timezone.utc_to_local(Time.now.utc))
+    end
+
     def work_hours_between(start_time, end_time)
       HourOfDay.work_hours_between(start_time, end_time, timezone)
     end
@@ -10,7 +17,11 @@ module ReviewBot
     end
 
     def work_hour?
-      HourOfDay.new(timezone.utc_to_local(Time.now.utc)).work_hour?
+      hour_of_day.work_hour?
+    end
+
+    def work_day?
+      hour_of_day.work_day?
     end
 
     def slack_emoji

--- a/spec/reminder_spec.rb
+++ b/spec/reminder_spec.rb
@@ -17,6 +17,73 @@ describe ReviewBot::Reminder do
     end
   end
 
+  describe '#notifications on non work days' do
+    around do |example|
+      Timecop.freeze(2018, 8, 31, 5, &example)
+    end
+
+    before do
+      allow(ReviewConfig).to receive(:env_config).and_return(JSON.parse(config))
+
+      allow_any_instance_of(Github::Client::PullRequests).to receive(:list).and_wrap_original do |m, *args|
+        VCR.use_cassette('pull_requests') do
+          m.call(*args)
+        end
+      end
+
+      allow_any_instance_of(Github::Client::Issues).to receive(:get).and_wrap_original do |m, *args|
+        VCR.use_cassette('issues') do
+          m.call(*args)
+        end
+      end
+
+      allow_any_instance_of(ReviewBot::PullRequest).to receive(:labels).and_return([])
+      allow_any_instance_of(ReviewBot::PullRequest).to receive(:reviews).and_return([])
+
+      allow_any_instance_of(ReviewBot::PullRequest).to receive(:needs_first_review?).and_return true
+      allow_any_instance_of(ReviewBot::PullRequest).to receive(:ez?).and_return true
+    end
+
+    let(:config) do
+      {'ministrycentered/reviewbot': {
+        'notification_hours': [5, 13],
+        'work_days': [1, 2, 3, 4],
+        'room': 'reviewbot',
+        'ignore_work_hours': ignore_work_hours,
+        'hours_to_review': 0,
+        'notify_in_progress_reviewers': false,
+        'reviewers': [
+          {
+            "github": "danielma",
+            "slack": "dma",
+            "not_user_slack": "not_dma",
+            "bamboohr": 1,
+            "timezone": "America/Los_Angeles"
+          },
+          {
+            "github": "awortham",
+            "slack": "adubs",
+            "not_user_slack": "not_adubs",
+            "bamboohr": 1,
+            "timezone": "America/Detroit"
+          }
+        ]
+      }}.to_json
+    end
+
+    context 'ignore_work_hours' do
+      context 'when ignore_work_hours is true' do
+        let(:ignore_work_hours) { true }
+
+        it 'does not send notifications' do
+          expect(ReviewBot::Notification).to_not receive(:new)
+
+          Rake::Task['remind'].invoke
+        end
+      end
+    end
+  end
+
   describe '#notifications' do
     around do |example|
       Timecop.freeze(2018, 8, 29, 5, &example)


### PR DESCRIPTION
This is a bug that was introduced by the new config option `ignore_work_hours`. The work days are also set using that work hours check, so notifications were firing all weekend. This fix checks to make sure the days are work days even if the work hours are not currently being used. 

I realize we are looping back through the suggested reviewers again, however I'm not really concerned with the performance on this. It's more of a quick fix.

Currently we have multiple usages of reviewbot. At some point we should probably rework things, getting it on a single decided way of using reviewbot. And at that point we could do a deeper dive. 