### PR TITLE
bug fix

### DIFF
--- a/lib/review_bot/reviewer.rb
+++ b/lib/review_bot/reviewer.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 module ReviewBot
   class Reviewer < OpenStruct
-    attr_reader :hour_of_day
-
-    def initialize(r)
-      super
-      @hour_of_day = HourOfDay.new(timezone.utc_to_local(Time.now.utc))
-    end
-
     def work_hours_between(start_time, end_time)
       HourOfDay.work_hours_between(start_time, end_time, timezone)
+    end
+
+    def hour_of_day
+      HourOfDay.new(timezone.utc_to_local(Time.now.utc))
     end
 
     def timezone


### PR DESCRIPTION
This is a bug that was introduced yesterday. Apparently _sometimes_ the Timezone is nil when initializing in the initialize method. By pulling that piece out and making it a method, this all runs and the notifications are sending. I tested this on People and Checkins. Both had reported theirs to be not sending.

![image](https://user-images.githubusercontent.com/6271986/59307275-07a5ee80-8c53-11e9-84ed-d6f9ff24700f.png)
